### PR TITLE
CDNを利用したアイコンを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Scroll Reveal</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -20,10 +21,10 @@
         </div>
       </div>
       <div class="media-icons">
-        <a href="#" class="icon"><i>A</i></a>
-        <a href="#" class="icon"><i>A</i></a>
-        <a href="#" class="icon"><i>A</i></a>
-        <a href="#" class="icon"><i>A</i></a>
+        <a href="https://ja-jp.facebook.com/" class="icon"><i class="fa-brands fa-facebook"></i></a>
+        <a href="https://www.instagram.com/" class="icon"><i class="fa-brands fa-instagram"></i></a>
+        <a href="https://twitter.com/" class="icon"><i class="fa-brands fa-twitter"></i></a>
+        <a href="https://www.youtube.com/" class="icon"><i class="fa-brands fa-youtube"></i></a>
       </div>
     </div>
   </section>
@@ -53,19 +54,19 @@
       <div class="content">
         <div class="media-info">
           <li>
-            <a href="#">Facebook</a>
+            <a href="https://ja-jp.facebook.com/"><i class="fa-brands fa-facebook"></i> Facebook</a>
           </li>
           <li>
-            <a href="#">Instagram</a>
+            <a href="https://www.instagram.com/"><i class="fa-brands fa-instagram"></i> Instagram</a>
           </li>
           <li>
-            <a href="#">Twitter</a>
+            <a href="https://twitter.com/"><i class="fa-brands fa-twitter"></i> Twitter</a>
           </li>
           <li>
-            <a href="#">Youtube</a>
+            <a href="https://www.youtube.com/"><i class="fa-brands fa-youtube"></i> Youtube</a>
           </li>
           <li>
-            <a href="#">Linkedin</a>
+            <a href="https://jp.linkedin.com/"><i class="fa-brands fa-linkedin"></i> Linkedin</a>
           </li>
         </div>
         <div class="image">

--- a/style.css
+++ b/style.css
@@ -73,7 +73,7 @@ section {
 }
 
 .media-icons {
-  margin-top: 10px;
+  margin-top: 70px;
 }
 
 .media-icons a {


### PR DESCRIPTION
# What
アイコンを追加
アイコンにリンク先を追加

# Why
前回プッシュした際は、アイコンの追加ができない状態であったため。
またアイコンの追加にはCDNを利用するが、公式サイトによればCDNのサポートを終了する旨が記載してあったため。

# 補足事項
サポートを終了するとあったが、実際には「これ以上新しいアイコンの追加やバグ修正は行わない」ということみたいで、CDNは現在も稼働している。しかしサポートしないと宣言されている以上、いつアイコンが使えなくなってもおかしくない。